### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
             <url>https://opensource.org/licenses/Apache-2.0</url>
         </license>
     </licenses>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+timeline</url>
+    <url>https://github.com/jenkinsci/pipeline-timeline-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/jenkins-timeline-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/jenkins-timeline-plugin.git</developerConnection>


### PR DESCRIPTION
## Description
Use GitHub instead of Jenkins Wiki as the source of documentation, see also [WEBSITE-637](https://issues.jenkins-ci.org/browse/WEBSITE-637).

### Comments:
The Wiki page for this plugin can't be found, maybe it never existed. The GitHub README seems to provide better information.


