### PR TITLE
[JENKINS-74150] Do not embed runtime script into `index.html`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,11 +12,23 @@
     <version>1.0.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.452.3</jenkins.version>
         <node.version>8.0.0</node.version>
         <npm.version>6.5.0</npm.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.452.x</artifactId>
+                <!-- Latest version goes here -->
+                <version>3850.vb_c5319efa_e29</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -115,12 +127,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/webapp_src/package.json
+++ b/webapp_src/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint src --ignore-pattern *.style.js --ignore-pattern serviceWorker.js",
     "lint-fix": "eslint src --ignore-pattern *.style.js --ignore-pattern serviceWorker.js --fix",
     "test-watch": "react-scripts test",
-    "build-to-plugin": "PUBLIC_URL=/plugin/pipeline-timeline npm run build && cp -r build/* ../src/main/webapp",
+    "build-to-plugin": "INLINE_RUNTIME_CHUNK=false PUBLIC_URL=/plugin/pipeline-timeline npm run build && cp -r build/* ../src/main/webapp",
     "deploy": "npm run test && npm run build-to-plugin"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

[React docs reference](https://create-react-app.dev/docs/advanced-configuration/#:~:text=By%20default%2C%20Create%20React%20App%20will%20embed%20the%20runtime%20script%20into%20index.html%20during%20the%20production%20build.%20When%20set%20to%20false%2C%20the%20script%20will%20not%20be%20embedded%20and%20will%20be%20imported%20as%20usual.%20This%20is%20normally%20required%20when%20dealing%20with%20CSP) which describes the approach I've taken.

Not tested enough yet. Been struggling to make it build on Windows with a single command, so had to do it in steps so far.

It's still not enough, the page plugin adds requests something called loader.js from www.gstatic.com. So won't work in CSP restrictive mode unless default policy is relaxed. I though about bumping up the React version, as 16.x seems quite old, but haven't tried it yet. Also stylesheets and fonts are requested from external websites. While fonts do not seem to be critical the page rendered nothing for me until I added the necessary source to style-src directive.


## DevQA

### DevQA Prep

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

### Comments:
<!-- Any other comments you want to include for reviewers. -->


